### PR TITLE
Fixed link Duplication.

### DIFF
--- a/collectlinks.go
+++ b/collectlinks.go
@@ -1,33 +1,74 @@
-// This package does the extraordinarily simple operation of parsing a given piece of html
+// Package collectlinks does extraordinarily simple operation of parsing a given piece of html
 // and providing you with all the hyperlinks hrefs it finds.
 package collectlinks
 
 import (
-  "golang.org/x/net/html"
-  "io"
+	"io"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
 )
 
-/* `All` takes a reader object (like the one returned from http.Get())
-   It returns a slice of strings representing the "href" attributes from
-   anchor links found in the provided html.
-
-   It does not close the reader passed to it.
-*/
+// All takes a reader object (like the one returned from http.Get())
+// It returns a slice of strings representing the "href" attributes from
+// anchor links found in the provided html.
+// It does not close the reader passed to it.
 func All(httpBody io.Reader) []string {
-  links := make([]string, 0)
-  page := html.NewTokenizer(httpBody)
-  for {
-    tokenType := page.Next()
-    if tokenType == html.ErrorToken {
-      return links
-    }
-    token := page.Token()
-    if tokenType == html.StartTagToken && token.DataAtom.String() == "a" {
-      for _, attr := range token.Attr {
-        if attr.Key == "href" {
-          links = append(links, attr.Val)
-        }
-      }
-    }
-  }
+	links := []string{}
+	col := []string{}
+	page := html.NewTokenizer(httpBody)
+	for {
+		tokenType := page.Next()
+		if tokenType == html.ErrorToken {
+			return links
+		}
+		token := page.Token()
+		if tokenType == html.StartTagToken && token.DataAtom.String() == "a" {
+			for _, attr := range token.Attr {
+				if attr.Key == "href" {
+					tl := trimHash(attr.Val)
+					col = append(col, tl)
+					resolv(&links, col)
+				}
+			}
+		}
+	}
+}
+
+// trimHash slices a hash # from the link
+func trimHash(l string) string {
+	if strings.Contains(l, "#") {
+		var index int
+		for n, str := range l {
+			if strconv.QuoteRune(str) == "'#'" {
+				index = n
+				break
+			}
+		}
+		return l[:index]
+	}
+	return l
+}
+
+// check looks to see if a url exits in the slice.
+func check(sl []string, s string) bool {
+	var check bool
+	for _, str := range sl {
+		if str == s {
+			check = true
+			break
+		}
+	}
+	return check
+}
+
+// resolv adds links to the link slice and insures that there is no repetition
+// in our collection.
+func resolv(sl *[]string, ml []string) {
+	for _, str := range ml {
+		if check(*sl, str) == false {
+			*sl = append(*sl, str)
+		}
+	}
 }


### PR DESCRIPTION
The links slice returned has no duplication's. E.g.
Suppose the home page contains the following links.
https://localhost:2016/home#images
https://localhost:2016/home#review
https://localhost:2016/home#adverts

Before, the result would be: 
["https://localhost:2016/home# images", "https://localhost:2016/home#review", "https://localhost:2016/home# adverts"]

Now :
["https://localhost:2016/home"]
